### PR TITLE
Rescue more file woes

### DIFF
--- a/lib/weigh/util.rb
+++ b/lib/weigh/util.rb
@@ -58,12 +58,13 @@ module Weigh
             Find.prune
           else
             size = FileTest.size(path)
-            #puts "File: #{path} is #{size}"
             puts "Found zero size file: #{path}" if verbose
             dir_size += size
           end
-        rescue IOError
-          puts "file vanished: " + path
+        rescue IOError => e
+          puts "File vanished #{path}:#{e.message}"
+        rescue Errno::ENOENT => e
+          puts "Could not open file #{path}:#{e.message}"
         end
       end
       data[:dir_size] = dir_size


### PR DESCRIPTION
A Errno::ENOENT is raised when the file no longer exists.  We should
rescue from this as well as IOError.
